### PR TITLE
Melhoria: Valor padrão do parâmetro windowSoftInputMode

### DIFF
--- a/src/android/AndroidManifest.xml
+++ b/src/android/AndroidManifest.xml
@@ -16,7 +16,7 @@
 			android:configChanges="orientation|uiMode|screenLayout|screenSize|smallestScreenSize|locale|fontScale|keyboard|keyboardHidden|navigation"
 			android:launchMode="singleTop"
 			android:screenOrientation="unspecified"
-			android:windowSoftInputMode="adjustPan">
+			android:windowSoftInputMode="adjustResize">
 
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />


### PR DESCRIPTION
Troquei valor de adjustPan para adjustResize pois quando o keyboard nativo aparece e a tela está configurada para adjustPan os campos dentro da webview podem ficar sobrepostos, utilizando adjustResize não ficam. Como o modelo parte da premissa de apps híbridos, o valor padrão pode ser adjustResize.
